### PR TITLE
Widgets override default template

### DIFF
--- a/src/SymEdit/Bundle/BlogBundle/Tests/Widget/Strategy/LatestPostStrategyTest.php
+++ b/src/SymEdit/Bundle/BlogBundle/Tests/Widget/Strategy/LatestPostStrategyTest.php
@@ -26,17 +26,19 @@ class LatestPostStrategyTest extends WidgetStrategyTest
                    ->method('getLatestPost')
                    ->will($this->returnValue('foo'));
 
+        $widget = $this->createWidget();
+
         $strategy = $this->getMock('SymEdit\Bundle\BlogBundle\Widget\Strategy\LatestPostStrategy', array('render'), array($repository));
         $strategy->expects($this->once())
                  ->method('render')
                  ->with(
-                    $this->equalTo('@SymEdit/Widget/Blog/latest-post.html.twig'),
+                    $this->equalTo($widget),
                     $this->equalTo(array(
                         'post' => 'foo',
                     ))
                  );
 
-        $strategy->execute($this->createWidget());
+        $strategy->execute($widget);
     }
 
     protected function createStrategy()
@@ -63,6 +65,7 @@ class LatestPostStrategyTest extends WidgetStrategyTest
     {
         return array(
             'show_image' => true,
+            'template' => '@SymEdit/Widget/Blog/latest-post.html.twig',
         );
     }
 

--- a/src/SymEdit/Bundle/BlogBundle/Tests/Widget/Strategy/PopularPostsStrategyTest.php
+++ b/src/SymEdit/Bundle/BlogBundle/Tests/Widget/Strategy/PopularPostsStrategyTest.php
@@ -26,17 +26,18 @@ class PopularPostsStrategyTest extends WidgetStrategyTest
                      array('post2', 2),
                  )));
 
+        $widget = $this->createWidget();
         $strategy = $this->createStrategy($reporter);
         $strategy->expects($this->once())
                  ->method('render')
                  ->with(
-                    $this->equalTo('@SymEdit/Widget/Blog/popular-posts.html.twig'),
+                    $this->equalTo($widget),
                     $this->equalTo(array(
                         'posts' => array('post1', 'post2'),
                     ))
                  );
 
-        $strategy->execute($this->createWidget());
+        $strategy->execute($widget);
     }
 
     protected function createStrategy($reporter = null)
@@ -73,6 +74,7 @@ class PopularPostsStrategyTest extends WidgetStrategyTest
     {
         return array(
             'max' => 3,
+            'template' => '@SymEdit/Widget/Blog/popular-posts.html.twig',
         );
     }
 

--- a/src/SymEdit/Bundle/BlogBundle/Widget/Strategy/AbstractPostStrategy.php
+++ b/src/SymEdit/Bundle/BlogBundle/Widget/Strategy/AbstractPostStrategy.php
@@ -14,7 +14,6 @@ namespace SymEdit\Bundle\BlogBundle\Widget\Strategy;
 use SymEdit\Bundle\BlogBundle\Repository\PostRepositoryInterface;
 use SymEdit\Bundle\WidgetBundle\Model\WidgetInterface;
 use SymEdit\Bundle\WidgetBundle\Widget\Strategy\AbstractWidgetStrategy;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractPostStrategy extends AbstractWidgetStrategy
 {
@@ -39,12 +38,5 @@ abstract class AbstractPostStrategy extends AbstractWidgetStrategy
             'public' => true,
             'last_modified' => $latestPost->getUpdatedAt(),
         );
-    }
-
-    public function getDefaultOptions(OptionsResolver $resolver)
-    {
-        $resolver->setDefaults(array(
-            'show_image' => true,
-        ));
     }
 }

--- a/src/SymEdit/Bundle/BlogBundle/Widget/Strategy/BlogCategoriesStrategy.php
+++ b/src/SymEdit/Bundle/BlogBundle/Widget/Strategy/BlogCategoriesStrategy.php
@@ -30,7 +30,7 @@ class BlogCategoriesStrategy extends AbstractWidgetStrategy
     {
         $root = $this->categoryRepository->findRoot();
 
-        return $this->render('@SymEdit/Widget/Blog/categories.html.twig', array(
+        return $this->render($widget, array(
             'root' => $root,
             'counts' => $widget->getOption('counts'),
         ));
@@ -43,13 +43,15 @@ class BlogCategoriesStrategy extends AbstractWidgetStrategy
                 'required' => false,
                 'label' => 'Display Counts',
                 'help_block' => 'Display Category counts next to label',
-            ));
+            ))
+        ;
     }
 
     public function getDefaultOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'counts' => true,
+            'template' => '@SymEdit/Widget/Blog/categories.html.twig',
         ));
     }
 

--- a/src/SymEdit/Bundle/BlogBundle/Widget/Strategy/LatestPostStrategy.php
+++ b/src/SymEdit/Bundle/BlogBundle/Widget/Strategy/LatestPostStrategy.php
@@ -21,7 +21,7 @@ class LatestPostStrategy extends AbstractPostStrategy
     {
         $post = $this->postRepository->getLatestPost();
 
-        return $this->render('@SymEdit/Widget/Blog/latest-post.html.twig', array(
+        return $this->render($widget, array(
             'post' => $post,
         ));
     }
@@ -40,6 +40,7 @@ class LatestPostStrategy extends AbstractPostStrategy
     {
         $resolver->setDefaults(array(
             'show_image' => true,
+            'template' => '@SymEdit/Widget/Blog/latest-post.html.twig',
         ));
     }
 

--- a/src/SymEdit/Bundle/BlogBundle/Widget/Strategy/PopularPostsStrategy.php
+++ b/src/SymEdit/Bundle/BlogBundle/Widget/Strategy/PopularPostsStrategy.php
@@ -34,7 +34,7 @@ class PopularPostsStrategy extends AbstractWidgetStrategy
         // We don't need the counts here
         $posts = array_map('current', $posts);
 
-        return $this->render('@SymEdit/Widget/Blog/popular-posts.html.twig', array(
+        return $this->render($widget, array(
             'posts' => $posts,
         ));
     }
@@ -59,6 +59,7 @@ class PopularPostsStrategy extends AbstractWidgetStrategy
     {
         $resolver->setDefaults(array(
             'max' => 3,
+            'template' => '@SymEdit/Widget/Blog/popular-posts.html.twig',
         ));
     }
 

--- a/src/SymEdit/Bundle/BlogBundle/Widget/Strategy/RecentPostsStrategy.php
+++ b/src/SymEdit/Bundle/BlogBundle/Widget/Strategy/RecentPostsStrategy.php
@@ -22,7 +22,7 @@ class RecentPostsStrategy extends AbstractPostStrategy
     {
         $posts = $this->postRepository->getRecent($widget->getOption('max'));
 
-        return $this->render('@SymEdit/Widget/Blog/recent-posts.html.twig', array(
+        return $this->render($widget, array(
             'posts' => $posts,
         ));
     }
@@ -47,6 +47,7 @@ class RecentPostsStrategy extends AbstractPostStrategy
     {
         $resolver->setDefaults(array(
             'max' => 3,
+            'template' => '@SymEdit/Widget/Blog/recent-posts.html.twig',
         ));
     }
 

--- a/src/SymEdit/Bundle/CoreBundle/Widget/Strategy/AbstractWidgetStrategy.php
+++ b/src/SymEdit/Bundle/CoreBundle/Widget/Strategy/AbstractWidgetStrategy.php
@@ -64,8 +64,8 @@ abstract class AbstractWidgetStrategy implements WidgetStrategyInterface
     /**
      * {@inheritDoc}
      */
-    public function render($name, array $parameters = array())
+    public function render(WidgetInterface $widget, array $parameters = array())
     {
-        return $this->templating->render($name, $parameters);
+        return $this->templating->render($widget->getOption('template'), $parameters);
     }
 }

--- a/src/SymEdit/Bundle/CoreBundle/Widget/Strategy/ContactInfoStrategy.php
+++ b/src/SymEdit/Bundle/CoreBundle/Widget/Strategy/ContactInfoStrategy.php
@@ -11,18 +11,15 @@
 
 namespace SymEdit\Bundle\CoreBundle\Widget\Strategy;
 
+use SymEdit\Bundle\CoreBundle\Model\PageInterface;
 use SymEdit\Bundle\WidgetBundle\Model\WidgetInterface;
-use SymEdit\Bundle\WidgetBundle\Widget\Strategy\TemplateStrategy;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ContactInfoStrategy extends TemplateStrategy
+class ContactInfoStrategy extends AbstractWidgetStrategy
 {
-    /**
-     * Return just the regular form, you can't change the template.
-     */
-    public function buildForm(FormBuilderInterface $builder)
+    public function execute(WidgetInterface $widget, PageInterface $page = null)
     {
+        return $this->render($widget);
     }
 
     public function getDefaultOptions(OptionsResolver $resolver)

--- a/src/SymEdit/Bundle/CoreBundle/Widget/Strategy/GoogleMapStrategy.php
+++ b/src/SymEdit/Bundle/CoreBundle/Widget/Strategy/GoogleMapStrategy.php
@@ -14,22 +14,17 @@ namespace SymEdit\Bundle\CoreBundle\Widget\Strategy;
 use SymEdit\Bundle\CoreBundle\Model\PageInterface;
 use SymEdit\Bundle\WidgetBundle\Model\WidgetInterface;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class GoogleMapStrategy extends AbstractWidgetStrategy
 {
     public function execute(WidgetInterface $widget, PageInterface $page = null)
     {
-        try {
-            $address = $widget->getOption('address');
+        $address = $widget->getOption('address');
 
-            $content = $this->render('@SymEdit/CMS/map.html.twig', array(
-                'query' => empty($address) ? null : $address,
-            ));
-        } catch (\Exception $e) {
-            $content = sprintf('There was an error rendering your template: "%s"', $e->getMessage());
-        }
-
-        return $content;
+        return $this->render($widget, array(
+            'query' => empty($address) ? null : $address,
+        ));
     }
 
     public function buildForm(FormBuilderInterface $builder)
@@ -43,7 +38,15 @@ class GoogleMapStrategy extends AbstractWidgetStrategy
                     'rows' => 5,
                     'cols' => 50,
                 ),
-            ));
+            ))
+        ;
+    }
+
+    public function getDefaultOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'template' => '@SymEdit/CMS/map.html.twig',
+        ));
     }
 
     public function getName()

--- a/src/SymEdit/Bundle/CoreBundle/Widget/Strategy/ListChildrenStrategy.php
+++ b/src/SymEdit/Bundle/CoreBundle/Widget/Strategy/ListChildrenStrategy.php
@@ -14,6 +14,7 @@ namespace SymEdit\Bundle\CoreBundle\Widget\Strategy;
 use SymEdit\Bundle\CoreBundle\Iterator\PageIterator;
 use SymEdit\Bundle\CoreBundle\Model\PageInterface;
 use SymEdit\Bundle\WidgetBundle\Model\WidgetInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ListChildrenStrategy extends AbstractWidgetStrategy
 {
@@ -26,9 +27,16 @@ class ListChildrenStrategy extends AbstractWidgetStrategy
             return false;
         }
 
-        return $this->render('@SymEdit/Widget/list-children.html.twig', array(
+        return $this->render($widget, array(
             'page' => $page,
             'children' => new PageIterator($page),
+        ));
+    }
+
+    public function getDefaultOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'template' => '@SymEdit/Widget/list-children.html.twig',
         ));
     }
 

--- a/src/SymEdit/Bundle/CoreBundle/Widget/Strategy/SubmenuStrategy.php
+++ b/src/SymEdit/Bundle/CoreBundle/Widget/Strategy/SubmenuStrategy.php
@@ -28,7 +28,7 @@ class SubmenuStrategy extends AbstractWidgetStrategy
             return false;
         }
 
-        return $this->render('@SymEdit/Widget/submenu.html.twig', array(
+        return $this->render($widget, array(
             'page' => $page,
             'nav_class' => $widget->getOption('nav_class'),
             'level' => $widget->getOption('level'),
@@ -59,6 +59,7 @@ class SubmenuStrategy extends AbstractWidgetStrategy
         $resolver->setDefaults(array(
             'level' => 1,
             'nav_class' => 'nav nav-pills nav-stacked',
+            'template' => '@SymEdit/Widget/submenu.html.twig',
         ));
     }
 

--- a/src/SymEdit/Bundle/MailChimpBundle/Widget/Strategy/SubscribeStrategy.php
+++ b/src/SymEdit/Bundle/MailChimpBundle/Widget/Strategy/SubscribeStrategy.php
@@ -38,7 +38,7 @@ class SubscribeStrategy extends AbstractWidgetStrategy
             'list' => $widget->getOption('list'),
         ));
 
-        return $this->render('@SymEdit/Widget/MailChimp/subscribe-form.html.twig', array(
+        return $this->render($widget, array(
             'form' => $form->createView(),
             'placeholder' => $widget->getOption('placeholder'),
             'button_text' => $widget->getOption('button_text'),
@@ -50,6 +50,7 @@ class SubscribeStrategy extends AbstractWidgetStrategy
         $resolver->setDefaults(array(
             'placeholder' => 'you@email.com',
             'button_text' => 'Subscribe!',
+            'template' => '@SymEdit/Widget/MailChimp/subscribe-form.html.twig',
         ));
     }
 

--- a/src/SymEdit/Bundle/MediaBundle/Widget/Strategy/GalleryStrategy.php
+++ b/src/SymEdit/Bundle/MediaBundle/Widget/Strategy/GalleryStrategy.php
@@ -24,7 +24,7 @@ class GalleryStrategy extends AbstractGalleryStrategy
             return;
         }
 
-        return $this->render('@SymEdit/Widget/Media/gallery.html.twig', array(
+        return $this->render($widget, array(
             'gallery' => $gallery,
         ));
     }
@@ -40,6 +40,13 @@ class GalleryStrategy extends AbstractGalleryStrategy
                 'property_value' => 'slug',
             ))
         ;
+    }
+
+    public function getDefaultOptions(\Symfony\Component\OptionsResolver\OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'template' => '@SymEdit/Widget/Media/gallery.html.twig',
+        ));
     }
 
     public function getName()

--- a/src/SymEdit/Bundle/MediaBundle/Widget/Strategy/SliderStrategy.php
+++ b/src/SymEdit/Bundle/MediaBundle/Widget/Strategy/SliderStrategy.php
@@ -25,7 +25,7 @@ class SliderStrategy extends AbstractGalleryStrategy
             return;
         }
 
-        return $this->render('@SymEdit/Widget/Media/slider.html.twig', array(
+        return $this->render($widget, array(
             'gallery' => $gallery,
             'thumbnails' => $widget->getOption('thumbnails'),
             'stretch' => $widget->getOption('stretch'),
@@ -39,6 +39,7 @@ class SliderStrategy extends AbstractGalleryStrategy
             'thumbnails' => false,
             'stretch' => false,
             'controls' => false,
+            'template' => '@SymEdit/Widget/Media/slider.html.twig',
         ));
     }
 

--- a/src/SymEdit/Bundle/WidgetBundle/Form/Type/WidgetType.php
+++ b/src/SymEdit/Bundle/WidgetBundle/Form/Type/WidgetType.php
@@ -11,11 +11,12 @@
 
 namespace SymEdit\Bundle\WidgetBundle\Form\Type;
 
+use SymEdit\Bundle\WidgetBundle\Form\DataTransformer\WidgetAssociationTransformer;
+use SymEdit\Bundle\WidgetBundle\Model\WidgetInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use SymEdit\Bundle\WidgetBundle\Form\DataTransformer\WidgetAssociationTransformer;
-use SymEdit\Bundle\WidgetBundle\Model\WidgetInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 class WidgetType extends AbstractType
 {
@@ -69,7 +70,20 @@ class WidgetType extends AbstractType
 
     public function buildOptionsForm(FormBuilderInterface $builder, array $options)
     {
-        $options['strategy']->buildForm($builder);
+        $strategy = $options['strategy'];
+
+        // Add custom template override
+        $builder
+            ->add('template', 'text', array(
+                'required' => true,
+                'help_block' => 'symedit.form.widget.options.template.help',
+                'constraints' => array(
+                    new NotBlank(),
+                ),
+            ))
+        ;
+
+        $strategy->buildForm($builder);
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/src/SymEdit/Bundle/WidgetBundle/Resources/translations/messages.en.yml
+++ b/src/SymEdit/Bundle/WidgetBundle/Resources/translations/messages.en.yml
@@ -21,3 +21,6 @@ symedit:
                     include_only: Include ONLY on specified
                     exclude_only: Exclude ONLY on specified
                 associations: Associations
+            options:
+                template:
+                    help: Override the default template to customize rendering

--- a/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/AbstractWidgetStrategy.php
+++ b/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/AbstractWidgetStrategy.php
@@ -52,8 +52,8 @@ abstract class AbstractWidgetStrategy implements WidgetStrategyInterface
         return $this->templating;
     }
 
-    public function render($name, array $parameters = array())
+    public function render(WidgetInterface $widget, array $parameters = array())
     {
-        return $this->templating->render($name, $parameters);
+        return $this->templating->render($widget->getOption('template'), $parameters);
     }
 }

--- a/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/AddThisStrategy.php
+++ b/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/AddThisStrategy.php
@@ -19,7 +19,7 @@ class AddThisStrategy extends AbstractWidgetStrategy
 {
     public function execute(WidgetInterface $widget)
     {
-        return $this->render('@SymEdit/Widget/addthis.html.twig', array(
+        return $this->render($widget, array(
             'include_script' => $widget->getOption('include_script'),
         ));
     }
@@ -31,13 +31,15 @@ class AddThisStrategy extends AbstractWidgetStrategy
                 'required' => false,
                 'label' => 'Include Javascript File?',
                 'help_block' => 'Try not to include the Javascript file twice on any page.',
-            ));
+            ))
+        ;
     }
 
     public function getDefaultOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'include_script' => true,
+            'template' => '@SymEdit/Widget/addthis.html.twig',
         ));
     }
 

--- a/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/DisqusStrategy.php
+++ b/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/DisqusStrategy.php
@@ -13,13 +13,14 @@ namespace SymEdit\Bundle\WidgetBundle\Widget\Strategy;
 
 use SymEdit\Bundle\WidgetBundle\Model\WidgetInterface;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 class DisqusStrategy extends AbstractWidgetStrategy
 {
     public function execute(WidgetInterface $widget)
     {
-        return $this->render('@SymEdit/Widget/disqus.html.twig', array(
+        return $this->render($widget, array(
             'shortname' => $widget->getOption('shortname'),
         ));
     }
@@ -33,7 +34,15 @@ class DisqusStrategy extends AbstractWidgetStrategy
                 'constraints' => array(
                     new NotBlank(),
                 ),
-            ));
+            ))
+        ;
+    }
+
+    public function getDefaultOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'template' => '@SymEdit/Widget/disqus.html.twig',
+        ));
     }
 
     public function getName()

--- a/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/HtmlStrategy.php
+++ b/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/HtmlStrategy.php
@@ -13,20 +13,22 @@ namespace SymEdit\Bundle\WidgetBundle\Widget\Strategy;
 
 use SymEdit\Bundle\WidgetBundle\Model\WidgetInterface;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class HtmlStrategy extends AbstractWidgetStrategy
 {
     public function execute(WidgetInterface $widget)
     {
-        return $this->render('@SymEdit/Widget/html.html.twig', array(
+        return $this->render($widget, array(
             'html' => $widget->getOption('html'),
         ));
     }
 
-    public function getDefaultOptions(\Symfony\Component\OptionsResolver\OptionsResolver $resolver)
+    public function getDefaultOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'html' => 'New HTML Widget',
+            'template' => '@SymEdit/Widget/html.html.twig',
         ));
     }
 

--- a/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/TemplateStrategy.php
+++ b/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/TemplateStrategy.php
@@ -12,8 +12,6 @@
 namespace SymEdit\Bundle\WidgetBundle\Widget\Strategy;
 
 use SymEdit\Bundle\WidgetBundle\Model\WidgetInterface;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints\NotBlank;
 
 class TemplateStrategy extends AbstractWidgetStrategy
 {
@@ -28,19 +26,6 @@ class TemplateStrategy extends AbstractWidgetStrategy
         }
 
         return $content;
-    }
-
-    public function buildForm(FormBuilderInterface $builder)
-    {
-        $builder
-            ->add('template', 'text', array(
-                'required' => true,
-                'label' => 'Template',
-                'constraints' => array(
-                    new NotBlank(),
-                ),
-            ))
-        ;
     }
 
     public function getName()

--- a/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/WidgetStrategyInterface.php
+++ b/src/SymEdit/Bundle/WidgetBundle/Widget/Strategy/WidgetStrategyInterface.php
@@ -61,8 +61,8 @@ interface WidgetStrategyInterface
     public function setTemplating(EngineInterface $templating);
 
     /**
-     * @param string $name       Template name
-     * @param array  $parameters Template parameters
+     * @param WidgetInterface $widget     Template name
+     * @param array           $parameters Template parameters
      */
-    public function render($name, array $parameters = array());
+    public function render(WidgetInterface $widget, array $parameters = array());
 }


### PR DESCRIPTION
Set the template in all default options so you can change the template of any widget. Will require a migration to add the default templates to existing widgets.